### PR TITLE
fix: use jsoo build-runtime

### DIFF
--- a/worker/eval.ml
+++ b/worker/eval.ml
@@ -141,3 +141,8 @@ let execute ~id ~line_number ~output code_text =
 let () =
   Ast_mapper.register_function :=
     fun _ f -> ppx_rewriters := f :: !ppx_rewriters
+
+module Force_aliases = struct
+  include Stdlib.Either
+  include Stdlib.Bigarray
+end


### PR DESCRIPTION
@patricoferris reported in #11 that libraries which declare a custom javascript runtime (for `external` functions) are not correctly exported... With this PR I managed to compile and run irmin in the browser with:

```shell
$ dune exec -- x-ocaml digestif.ocaml irmin.mem -o irmin.js
```

```html
<script async src="x-ocaml.js" src-worker="x-ocaml.worker.js" src-load="irmin.js"></script>
<x-ocaml>
module Store = Irmin_mem.KV.Make (Irmin.Contents.String)

let info () = Store.Info.v 0L

let _ =
  let open Lwt.Syntax in
  let* repo = Store.Repo.v (Irmin_mem.config ()) in
  let* main = Store.main repo in
  let* () = Store.set_exn main ~info [ "test" ] "hello world" in
  let* output = Store.get main [ "test" ] in
  print_endline output;
  Lwt.return_unit
</x-ocaml>
```

But I'm not sure if this is the right fix, because it's a bit hacky!

The issue I observed is that the `bigstringaf` library exports this [runtime.js file](https://github.com/inhabitedtype/bigstringaf/blob/master/lib/runtime.js), which declares a bunch of functions that depends on [jsoo's bigstring.js runtime](https://github.com/ocsigen/js_of_ocaml/blob/master/runtime/js/bigstring.js), which wasn't imported. It turns out that the `js_of_ocaml` executable provides a `build-runtime` command to compile bigstringaf `runtime.js` properly. However the resulting runtime erases the previous one, so I hacked around... surely there's a better way!